### PR TITLE
Minor edits to evan.typ to make Typst more like LaTeX

### DIFF
--- a/typst/packages/local/evan/1.0.0/evan.typ
+++ b/typst/packages/local/evan/1.0.0/evan.typ
@@ -50,7 +50,8 @@
 
 #let pmod(x) = $space (mod #x)$
 #let vocab(body) = strong(text(blue, body))
-#set enum(indent: .25in)
+#set enum(indent: .125in)
+#set list(indent: .125in)
 
 #let url(s) = {
   link(s, text(font:fonts.mono, s))

--- a/typst/packages/local/evan/1.0.0/evan.typ
+++ b/typst/packages/local/evan/1.0.0/evan.typ
@@ -48,6 +48,10 @@
 
 #let proof = thmproof("proof", "Proof")
 
+#let pmod(x) = $space (mod #x)$
+#let vocab(body) = strong(text(blue, body))
+#set enum(indent: .25in)
+
 #let url(s) = {
   link(s, text(font:fonts.mono, s))
 }


### PR DESCRIPTION
- `pmod` now works like `\pmod` in LaTeX
- `vocab` now works like `\vocab` in evan.sty
- numbered and unordered lists now have indenting similar to in LaTeX