### PR TITLE
fix: `LaTeX` case wrong in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ Keybindings are optimized for [Dvorak](https://en.wikipedia.org/wiki/Dvorak_Simp
 - Fish uses 4 spaces for indentation as well.
 - Shell, Typescript, JS, CSS, VimScript use 2 spaces for indentation.
 - Markdown/JS/CSS use `prettier` for formatting.
-- LateX and Markdown also use 2 spaces for indentation.
+- LaTeX and Markdown also use 2 spaces for indentation.
 - If not specified, generally use 2 spaces for tabs.


### PR DESCRIPTION
fix: `latex` word wrong